### PR TITLE
Add an ~npc command and 4 corresponding tables. Generates an NPC with name, race, gender, and an appearance/demeanour adjective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+token.txt
+bin/
+obj/

--- a/src/Commands/NPCCommand.cs
+++ b/src/Commands/NPCCommand.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Text.RegularExpressions;
+using Generator.Tables.AppearanceAdjectives;
+using Generator.Tables.Genders;
+using Generator.Tables.Names;
+using Generator.Tables.Races;
+using Generator.Utils;
+using Toolkit.Generator;
+
+namespace Generator.Commands
+{
+    public class NPCCommand : IGenerator
+    {
+        private Random _rng;
+        private Logger _logger;
+
+        public NPCCommand(Random rng, Logger logger)
+        {
+            _rng = rng;
+            _logger = logger;
+        }
+
+        private string GenerateFromATable(ITable table, string[] commands)
+        {
+            var randomValue = _rng.Next(table.Max);
+
+            Regex re = new Regex(@"\d+");
+            foreach (string element in commands)
+            {
+                if (re.IsMatch(element))
+                {
+                    randomValue = Int32.Parse(element);
+                    break;
+                }
+            }
+
+            if (randomValue > table.Max || randomValue < table.Min)
+                return $"Provided value is out of range. Selected table has {table.Max} rows.";
+
+            return $"{table.Fetch(randomValue)} ({randomValue})";
+        }
+
+        public string Generate(string[] commands)
+        {
+            ITable genderTable = new Genders();
+            ITable appearanceAdjectivesTable = new AppearanceAdjectives();
+            ITable namesTable = new Names();
+            ITable racesTable = new Races();
+
+            string name = GenerateFromATable(namesTable, commands);
+            string gender = GenerateFromATable(genderTable, commands);
+            string race = GenerateFromATable(racesTable, commands);
+            string appearanceAdjective = GenerateFromATable(appearanceAdjectivesTable, commands);
+
+            string genderPronoun = "";
+
+            if (gender.Contains("female")) {
+                genderPronoun = "She";
+            } else if (gender.Contains("male")) {
+                genderPronoun = "He";
+            } else {
+                genderPronoun = "They";
+            }
+
+            return $"{name}, a {gender} {race}, stands before you. {genderPronoun} appears {appearanceAdjective}.";
+        }
+    }
+}

--- a/src/Interfaces/ITable.cs
+++ b/src/Interfaces/ITable.cs
@@ -5,6 +5,7 @@ namespace Toolkit.Generator
     public interface ITable
     {
         int Max { get; set; }
+        int Min { get; set; }
         Percentile[] Table { get; set; }
         string Fetch(int position);
     }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -25,14 +26,7 @@ namespace Generator
 
             _client.Log += _logger.Log;
 
-            //  You can assign your bot token to a string, and pass that in to connect.
-            //  This is, however, insecure, particularly if you plan to have your code hosted in a public repository.
-            var token = "";
-
-            // Some alternative options would be to keep your token in an Environment Variable or a standalone file.
-            // var token = Environment.GetEnvironmentVariable("NameOfYourEnvironmentVariable");
-            // var token = File.ReadAllText("token.txt");
-            // var token = JsonConvert.DeserializeObject<AConfigurationClass>(File.ReadAllText("config.json")).Token;
+            var token = File.ReadAllText("token.txt");
 
             _client.MessageUpdated += MessageUpdated;
             _client.MessageReceived += OnMessageReceivedAsync;
@@ -85,6 +79,10 @@ namespace Generator
                 case "ws":
                     WildSurgeCommand wcs = new WildSurgeCommand(_rng, _logger);
                     response = wcs.Generate(commands);
+                    break;
+                case "npc":
+                    NPCCommand npcc = new NPCCommand(_rng, _logger);
+                    response = npcc.Generate(commands);
                     break;
                 default:
                     response += "Command not recognized";

--- a/src/Tables/NPC/AppearanceAdjectives.cs
+++ b/src/Tables/NPC/AppearanceAdjectives.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using Generator.Models;
+using Toolkit.Generator;
+
+namespace Generator.Tables.AppearanceAdjectives
+{
+    public class AppearanceAdjectives : ITable
+    {
+        private Percentile[] _table = {
+            new Percentile(0,50,"disheveled"),
+            new Percentile(51,99,"jovial")
+        };
+
+        public AppearanceAdjectives()
+        {
+            Table = _table;
+            Max = _table[_table.Length-1].max;
+        }
+
+        public int Max { get; set; }
+        public int Min { get; set; }
+        public Percentile[] Table { get; set; }
+
+        public string Fetch(int position)
+        {
+            var response = "";
+            foreach (Percentile element in Table)
+            {
+                if (Enumerable.Range(element.min,element.max).Contains(position))
+                    response = element.value;
+            }
+            return response;
+        }
+    }
+}

--- a/src/Tables/NPC/Genders.cs
+++ b/src/Tables/NPC/Genders.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using Generator.Models;
+using Toolkit.Generator;
+
+namespace Generator.Tables.Genders
+{
+    public class Genders : ITable
+    {
+        private Percentile[] _table = {
+            new Percentile(0,500,"male"),
+            new Percentile(501,998,"female"),
+            new Percentile(999, 1000,"non-binary")
+        };
+
+        public Genders()
+        {
+            Table = _table;
+            Max = _table[_table.Length-1].max;
+        }
+
+        public int Max { get; set; }
+        public int Min { get; set; }
+        public Percentile[] Table { get; set; }
+
+        public string Fetch(int position)
+        {
+            var response = "";
+            foreach (Percentile element in Table)
+            {
+                if (Enumerable.Range(element.min,element.max).Contains(position))
+                    response = element.value;
+            }
+            return response;
+        }
+    }
+}

--- a/src/Tables/NPC/Names.cs
+++ b/src/Tables/NPC/Names.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using Generator.Models;
+using Toolkit.Generator;
+
+namespace Generator.Tables.Names
+{
+    public class Names : ITable
+    {
+        private Percentile[] _table = {
+            new Percentile(0,1,"Randy"),
+            new Percentile(2,3,"Matt"),
+            new Percentile(4,5,"Melanie"),
+            new Percentile(6,7,"Josh"),
+            new Percentile(8,9,"Ryan"),
+            new Percentile(10,11,"Colin"),
+            new Percentile(12,13,"Chris")
+        };
+
+        public Names()
+        {
+            Table = _table;
+            Max = _table[_table.Length-1].max;
+        }
+
+        public int Max { get; set; }
+        public int Min { get; set; }
+        public Percentile[] Table { get; set; }
+
+        public string Fetch(int position)
+        {
+            var response = "";
+            foreach (Percentile element in Table)
+            {
+                if (Enumerable.Range(element.min,element.max).Contains(position))
+                    response = element.value;
+            }
+            return response;
+        }
+    }
+}

--- a/src/Tables/NPC/Races.cs
+++ b/src/Tables/NPC/Races.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using Generator.Models;
+using Toolkit.Generator;
+
+namespace Generator.Tables.Races
+{
+    public class Races : ITable
+    {
+        private Percentile[] _table = {
+
+            // All odd races are 1 in 1000 or 0.1%
+            new Percentile(0,1,"Grung"),
+            new Percentile(2,3,"Locathah"),
+            new Percentile(4,5,"Verdan"),
+            new Percentile(6,7,"Simic Hybrid"),
+            new Percentile(8,9,"Vedalken"),
+            new Percentile(10,11,"Centaur"),
+            new Percentile(12,13,"Loxodon"),
+            new Percentile(14,15,"Minotaur"),
+            new Percentile(16,17,"Gith"),
+            new Percentile(18,19,"Shifter"),
+            new Percentile(20,21,"Warforged"),
+            new Percentile(22,23,"Changeling"),
+            new Percentile(24,25,"Kalashtar"),
+            new Percentile(26,27,"Orc of Eberron"),
+            new Percentile(28,29,"Tortle"),
+            new Percentile(30,31,"Feral Tiefling"),
+            new Percentile(32,33,"Tabaxi"),
+            new Percentile(34,35,"Triton"),
+            new Percentile(36,37,"Yuan-ti Pureblood"),
+            new Percentile(38,39,"Orc"),
+            new Percentile(40,41,"Lizardfolk"),
+            new Percentile(42,43,"Kobold"),
+            new Percentile(44,45,"Goblin"),
+            new Percentile(46,47,"Hobgoblin"),
+            new Percentile(48,49,"Kenku"),
+            new Percentile(50,51,"Firbolg"),
+            new Percentile(52,53,"Bugbear"),
+            new Percentile(54,55,"Aasimar"),
+            new Percentile(56,57,"Aarakocra"),
+            new Percentile(58,59,"Genasi"),
+            new Percentile(60,61,"Goliath"),
+            new Percentile(62,63,"Leonin"),
+            new Percentile(64,65,"Satyr"),
+            new Percentile(66,67,"Eldar"),
+            new Percentile(68,69,"Half-Orc"),
+
+            // Humans are 23% chance
+            new Percentile(69,300,"Human"),
+
+            // Al other races are 10% chance
+            new Percentile(300,400,"Tiefling"),
+            new Percentile(401,500,"Halfling"),
+            new Percentile(501,600,"Half-Elf"),
+            new Percentile(601,700,"Gnome"),
+            new Percentile(701,800,"Elf"),
+            new Percentile(801,900,"Dwarf"),
+            new Percentile(901,1000,"Dragonborn")
+
+        };
+
+        public Races()
+        {
+            Table = _table;
+            Max = _table[_table.Length-1].max;
+        }
+
+        public int Max { get; set; }
+        public int Min { get; set; }
+        public Percentile[] Table { get; set; }
+
+        public string Fetch(int position)
+        {
+            var response = "";
+            foreach (Percentile element in Table)
+            {
+                if (Enumerable.Range(element.min,element.max).Contains(position))
+                    response = element.value;
+            }
+            return response.ToLower();
+        }
+    }
+}

--- a/src/Tables/Weather/HeavyPrecipitation.cs
+++ b/src/Tables/Weather/HeavyPrecipitation.cs
@@ -20,6 +20,7 @@ namespace Generator.Tables.Weather
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)

--- a/src/Tables/Weather/LightPrecipitation.cs
+++ b/src/Tables/Weather/LightPrecipitation.cs
@@ -21,6 +21,7 @@ namespace Generator.Tables.Weather
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)

--- a/src/Tables/Weather/MediumPrecipitation.cs
+++ b/src/Tables/Weather/MediumPrecipitation.cs
@@ -21,6 +21,7 @@ namespace Generator.Tables.Weather
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)

--- a/src/Tables/Weather/TemperateWeather.cs
+++ b/src/Tables/Weather/TemperateWeather.cs
@@ -23,6 +23,7 @@ namespace Generator.Tables.Weather
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)

--- a/src/Tables/WildMagic/ChaosMagic.cs
+++ b/src/Tables/WildMagic/ChaosMagic.cs
@@ -10016,6 +10016,7 @@ namespace Generator.Tables.WildMagic
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)

--- a/src/Tables/WildMagic/EldritchMagic.cs
+++ b/src/Tables/WildMagic/EldritchMagic.cs
@@ -67,6 +67,7 @@ namespace Generator.Tables.WildMagic
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)

--- a/src/Tables/WildMagic/WildMagic.cs
+++ b/src/Tables/WildMagic/WildMagic.cs
@@ -67,6 +67,7 @@ namespace Generator.Tables.WildMagic
         }
 
         public int Max { get; set; }
+        public int Min { get; set; }
         public Percentile[] Table { get; set; }
 
         public string Fetch(int position)


### PR DESCRIPTION
* Program now reads discord bot token from a gitignored `token.txt` file located at the root of the `src/` folder - `src/token.txt`

* Add an ~npc command and 4 corresponding tables. Generates an NPC with name, race, gender, and an appearance/demeanour adjective

![image](https://user-images.githubusercontent.com/931327/89475881-959a3e00-d75f-11ea-92c3-0bfad8718b51.png)

* Names table contains placeholder values, for now (`randy`, `matt`, etc) - let's add names or possibly call out to a random name generator API at some point, if one exists?

* Races table is 0.01% chance of a weird race, 10% chance of misc normal races, ~23% chance of human

* Gender table is male/female/non-binary

* Appearance/Demeanour table contains only 2 values for now (`jovial` or `disheveled`) - let's add more and maybe enhance the "generate a small sentence about them" logic in the future